### PR TITLE
ArrayHelpers import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,9 @@ All notable changes to `time-helpers` will be documented in this file
 ## 1.1.1 - 2021-03-30
 - fix sfneal/actions, sfneal/array-helpers & spatie/laravel-analytics version syntax
 - fix Travis CI config to enable code coverage uploads
+
+
+## 1.2.0 - 2021-03-31
+- bump sfneal/array-helpers min version to 1.2
+- fix `TimePeriods::mapMethods()` to use `ArrayHelpers` import instead of helper function
+- cut use of `AbstractService` extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,8 @@ All notable changes to `time-helpers` will be documented in this file
 - add testing infrastructure for testing Duration trait by adding test model, migration & factory with test cases
 - bump dev requirement orchestra/testbench min version to 6.7 
 - add "illuminate/database": ">=8.2" to dev requirements to support Model Factories with custom namespaces
+
+
+## 1.1.1 - 2021-03-30
+- fix sfneal/actions, sfneal/array-helpers & spatie/laravel-analytics version syntax
+- fix Travis CI config to enable code coverage uploads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,5 @@ All notable changes to `time-helpers` will be documented in this file
 
 
 ## 1.2.0 - 2021-03-31
-- bump sfneal/array-helpers min version to 1.2
 - fix `TimePeriods::mapMethods()` to use `ArrayHelpers` import instead of helper function
 - cut use of `AbstractService` extension

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sfneal/actions": "^1.0",
-        "sfneal/array-helpers": "^1.0",
+        "sfneal/array-helpers": "^1.2",
         "spatie/laravel-analytics": "^3.10"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sfneal/array-helpers": "^1.2",
+        "sfneal/array-helpers": "^1.0",
         "spatie/laravel-analytics": "^3.10"
     },
     "require-dev": {

--- a/src/Carbonate.php
+++ b/src/Carbonate.php
@@ -3,9 +3,8 @@
 namespace Sfneal\Helpers\Time;
 
 use Carbon\Carbon;
-use Sfneal\Actions\AbstractService;
 
-class Carbonate extends AbstractService
+class Carbonate
 {
     /**
      * Create a Carbon datetime objects $x days forward/backward in the past or future.

--- a/src/TimeConverter.php
+++ b/src/TimeConverter.php
@@ -2,9 +2,7 @@
 
 namespace Sfneal\Helpers\Time;
 
-use Sfneal\Actions\AbstractService;
-
-class TimeConverter extends AbstractService
+class TimeConverter
 {
     // todo: could $hours & $minutes be removed and convert everything from seconds?
 

--- a/src/TimePeriods.php
+++ b/src/TimePeriods.php
@@ -2,9 +2,7 @@
 
 namespace Sfneal\Helpers\Time;
 
-use Sfneal\Actions\AbstractService;
-
-class TimePeriods extends AbstractService
+class TimePeriods
 {
     /**
      * This Month.

--- a/src/TimePeriods.php
+++ b/src/TimePeriods.php
@@ -2,6 +2,8 @@
 
 namespace Sfneal\Helpers\Time;
 
+use Sfneal\Helpers\Arrays\ArrayHelpers;
+
 class TimePeriods
 {
     /**
@@ -158,13 +160,18 @@ class TimePeriods
      */
     private static function mapMethods(array $methods): array
     {
-        return arrayFlattenKeys(array_map(function ($method, $times) {
-            return [$method => $times];
-        },
+        $array = array_map(
+            function ($method, $times) {
+                return [$method => $times];
+            },
             $methods,
-            array_map(function ($method) {
-                return self::{$method}();
-            }, $methods)
-        ), false);
+            array_map(
+                function ($method) {
+                    return self::{$method}();
+                },
+                $methods
+            )
+        );
+        return (new ArrayHelpers($array))->arrayFlattenKeys(false);
     }
 }


### PR DESCRIPTION
- fix `TimePeriods::mapMethods()` to use `ArrayHelpers` import instead of helper function
- cut use of `AbstractService` extension