### PR TITLE
Optimize `TimePeriods::mapMethods()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,3 +102,8 @@ All notable changes to `time-helpers` will be documented in this file
 ## 1.2.2 - 2021-07-30
 - optimize assertions methods used in `TimePeriodTest`
 - add test methods for testing all of `TimePeriods` public methods
+
+
+## 1.2.3 - 2021-07-30
+- optimize `TimePeriods::mapMethods()` & removed use of `ArrayHelpers`
+- cut sfneal/array-helpers from composer requirements

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sfneal/array-helpers": "^1.0",
         "spatie/laravel-analytics": "^3.10"
     },
     "require-dev": {

--- a/src/TimePeriods.php
+++ b/src/TimePeriods.php
@@ -2,8 +2,6 @@
 
 namespace Sfneal\Helpers\Time;
 
-use Sfneal\Helpers\Arrays\ArrayHelpers;
-
 class TimePeriods
 {
     /**
@@ -160,19 +158,10 @@ class TimePeriods
      */
     private static function mapMethods(array $methods): array
     {
-        $array = array_map(
-            function ($method, $times) {
-                return [$method => $times];
-            },
-            $methods,
-            array_map(
-                function ($method) {
-                    return self::{$method}();
-                },
-                $methods
-            )
-        );
-
-        return (new ArrayHelpers($array))->arrayFlattenKeys(false);
+        $arr = [];
+        foreach ($methods as $method) {
+            $arr[$method] = self::{$method}();
+        }
+        return $arr;
     }
 }

--- a/src/TimePeriods.php
+++ b/src/TimePeriods.php
@@ -162,6 +162,7 @@ class TimePeriods
         foreach ($methods as $method) {
             $arr[$method] = self::{$method}();
         }
+
         return $arr;
     }
 }


### PR DESCRIPTION
- optimize `TimePeriods::mapMethods()` & removed use of `ArrayHelpers`
- cut sfneal/array-helpers from composer requirements